### PR TITLE
Use a digit-only input for spool ID

### DIFF
--- a/panels/mmu_filaments.py
+++ b/panels/mmu_filaments.py
@@ -179,6 +179,7 @@ class Panel(ScreenPanel):
         self.labels['id_entry'].connect("changed", self.select_spool_id)
         self.labels['id_entry'].grab_focus_without_selecting()
         self.labels['id_entry'].set_max_length(4)
+        self.labels['id_entry'].set_input_purpose(Gtk.InputPurpose.DIGITS)
 
         self.labels['filament'].set_vexpand(False)
         self.labels['filament'].get_style_context().add_class("mmu_recover")


### PR DESCRIPTION
Sets spool ID field to input type DIGIT and adds support in the on-screen keyboard for this input type.  They on-screen keyboard can now display a number pad instead of the standard keyboard if the widget requesting the keyboard has input type DIGIT.

I got tired of having to press another button and navigate the number row on the on-screen keyboard.  The existing KlipperScreen keyboard didn't support any InputType hinting.  Special layout behavior was added for the DIGIT input type so that columns are aligned properly (instead of being offset like the normal keyboard).

It looks like this:
![image](https://github.com/user-attachments/assets/7d316c24-1a2d-43d5-b28c-a8730caf899f)
