### PR TITLE
Making Filament Edit button visible in 480x320 screens

### DIFF
--- a/panels/mmu_filaments.py
+++ b/panels/mmu_filaments.py
@@ -103,7 +103,7 @@ class Panel(ScreenPanel):
             grid.attach(color,      6, i, 2, 1)
             grid.attach(material,   8, i, 3, 1)
             grid.attach(tools,     11, i, 3, 1)
-            grid.attach(edit,      14, i, 2, 1)
+            grid.attach(edit,      13, i, 2, 1)
 
         self.labels['unknown_icon'] = self._gtk.Image('mmu_unknown', width=img_width, height=img_height).get_pixbuf()
         self.labels['available_icon'] = self._gtk.Image('mmu_tick', width=img_width, height=img_height).get_pixbuf()
@@ -223,13 +223,17 @@ class Panel(ScreenPanel):
         edit_grid.attach(pad,                       0, 3, 16, 1)
 
         scroll = self._gtk.ScrolledWindow()
-        scroll.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         scroll.add(grid)
+
+        edit_scroll = self._gtk.ScrolledWindow()
+        edit_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        edit_scroll.add(edit_grid)
 
         self.labels['layers'] = layers = Gtk.Notebook()
         layers.set_show_tabs(False)
         layers.insert_page(scroll, None, 0)
-        layers.insert_page(edit_grid, None, 1)
+        layers.insert_page(edit_scroll, None, 1)
 
         self.content.add(layers)
 


### PR DESCRIPTION
The "Edit" panel lacked scrollbars and made the Edit button not be fully visible in low-res screens like the BTT TFT35 (3.5" SPI).

This commit moves the edit column one place left (13 instead of 14) and adds automatic horizontal scrollbars (for both edit and non-edit panels, for consistency), which makes the UI adapt and show the entire content without actually needing scrollbars.

Before the code change:
![image](https://github.com/user-attachments/assets/c3086c65-0e27-46cf-8b4d-c5d897ff1bb5)

After the code change:
![image](https://github.com/user-attachments/assets/0a7782c4-2b5c-4950-b293-d54369087883)