### PR TITLE
Fix: Support 8-digit hex colors (Mainsail) in MMU menus

### DIFF
--- a/panels/mmu_filaments.py
+++ b/panels/mmu_filaments.py
@@ -326,9 +326,15 @@ class Panel(ScreenPanel):
         return tool_str
 
     def get_color_details(self, gate_color):
+        if gate_color and len(gate_color) == 8:
+            try:
+                int(gate_color, 16)
+                gate_color = gate_color[:6]
+            except ValueError:
+                pass
         color = Gdk.RGBA()
-        if not Gdk.RGBA.parse(color, gate_color):
-            Gdk.RGBA.parse(color, '#' + gate_color)
+        if not Gdk.RGBA.parse(color, gate_color if gate_color else ""):
+            Gdk.RGBA.parse(color, '#' + gate_color if gate_color else "")
         return color
 
     # gate_tool_map = [ { 'tools': <list of tools mapped to this gate> } ]
@@ -479,4 +485,3 @@ class Panel(ScreenPanel):
         self._screen.remove_keyboard()
         self._screen.set_focus(None)
         self.labels['layers'].set_current_page(0) # Gate list layer
-

--- a/panels/mmu_main.py
+++ b/panels/mmu_main.py
@@ -597,9 +597,15 @@ class Panel(ScreenPanel):
         self.update_tool_buttons(tool_sensitive)
 
     def get_rgb_color(self, gate_color):
+        if gate_color and len(gate_color) == 8:
+            try:
+                int(gate_color, 16)
+                gate_color = gate_color[:6]
+            except ValueError:
+                pass
         color = Gdk.RGBA()
-        if not Gdk.RGBA.parse(color, gate_color.lower()):
-            if not Gdk.RGBA.parse(color, '#' + gate_color):
+        if not Gdk.RGBA.parse(color, gate_color.lower() if gate_color else ""):
+            if not Gdk.RGBA.parse(color, '#' + gate_color if gate_color else ""):
                 return ""
         rgb_color = "#{:02x}{:02x}{:02x}".format(int(color.red * 255), int(color.green * 255), int(color.blue * 255))
         return rgb_color

--- a/panels/mmu_picker.py
+++ b/panels/mmu_picker.py
@@ -97,9 +97,16 @@ class Panel(ScreenPanel):
         for i in range(num_tools):
             t_map = tool_map[i]
             gate = t_map['gate']
+            color_str = gate_color[gate]
+            if color_str and len(color_str) == 8:
+                try:
+                    int(color_str, 16)
+                    color_str = color_str[:6]
+                except ValueError:
+                    pass
             color = Gdk.RGBA()
-            if not Gdk.RGBA.parse(color, gate_color[gate]):
-                Gdk.RGBA.parse(color, '#' + gate_color[gate])
+            if not Gdk.RGBA.parse(color, color_str if color_str else ""):
+                Gdk.RGBA.parse(color, '#' + color_str if color_str else "")
 
             gate_str = (f"Gate #{t_map['gate']}")
             alt_gate_str = ''


### PR DESCRIPTION

### Description

  **Summary**
  This PR resolves an issue where custom filament colors set in Mainsail were not displaying correctly in KlipperScreen
  MMU panels.
  Mainsail stores colors as 8-digit hex strings (including alpha channel), which caused the existing color parsing logic
  to fail, resulting in colors defaulting to white/empty.

  **Changes**
   * Color Parsing: Added a lightweight check to detect 8-digit hex strings. If found, the alpha channel is trimmed
     (creating a standard 6-digit RRGGBB hex code) to ensure reliable parsing by Gdk.RGBA.
   * Safety: Added a safeguard to handle None inputs gracefully, preventing potential TypeErrors before the parsing
     stage.

  **Impact**
   * Correctly displays colors synchronized from Mainsail.
   * Existing functionality for standard hex codes and named colors remains unchanged.
