### PR TITLE
Fix IndentationError in mmu_main.py extruder temp update

### DIFF
--- a/panels/mmu_main.py
+++ b/panels/mmu_main.py
@@ -514,8 +514,8 @@ class Panel(ScreenPanel, MmuMixin):
 
                 current_extruder = self._printer.get_stat("toolhead", "extruder")
                 if 'configfile' not in data:
-                if current_extruder in data:
-                    self.update_extruder_temp()
+                    if current_extruder in data:
+                        self.update_extruder_temp()
 
             except KeyError:
                 # Almost certainly a version mismatch of Happy Hare on the printer


### PR DESCRIPTION
## Summary
Fixes a broken indentation block in `panels/mmu_main.py` that caused an `IndentationError`. The nested `if current_extruder in data:` / `self.update_extruder_temp()` lines were not indented under the preceding `if 'configfile' not in data:` guard.

## Changes
- Correctly indent the `if current_extruder in data:` check and its `update_extruder_temp()` call so they nest inside the `if 'configfile' not in data:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)